### PR TITLE
[Feature] - release drafter yaml 추가

### DIFF
--- a/.github/release-drafter-config.yaml
+++ b/.github/release-drafter-config.yaml
@@ -1,0 +1,31 @@
+name-template: "v$RESOLVED_VERSION 🌈"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "🧰 Maintenance"
+    label: "chore"
+change-template: "- $TITLE (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,28 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v6
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        with:
+          config-name: release-drafter-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
- 공식문서에서 제공하는 yaml에서 config.yml의 경우 이름을 release-drafter-config.yaml로 변경하였습니다.
- github의 workflow인 release-drafter를 활용하여 release note 생성을 자동화합니다.
    - workflow에서 제공하는 RESOLVED_VERSION 키워드를 사용하여 PR 시 추가한 Labels에 따라 버전을 관리합니다.
        - Major(v1.0.0): 이전 버전과 호환되지 않는 새로운 버전
        - Minor(v0.1.0): 이전 버전과 호환되며 새로운 기능 추가
        - Patch(v0.0.1): 이전 버전과 호환되며 버그 및 오타 등 수정 사항 반영

### 참고자료
- https://github.com/release-drafter/release-drafter?tab=readme-ov-file
- https://suho0303.tistory.com/56