### PR TITLE
[chore] - ci workflow trigger 조건 변경

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,6 @@
 name: Docker CI PIPELINE
 
 on:
-  push:
-    branches: ["main"]
   release:
     types: [published]
 


### PR DESCRIPTION
## 연관 이슈
- close #12

## 설명
> 작업에 대한 설명을 작성해주세요.
- 기존 ci workflow trigger 조건은 아래와 같음
    1. main 브랜치 푸쉬 이벤트 발생 시
    2. release가 퍼블리쉬 된 경우
- 위 조건 중 1번 제거 예정: ci workflow는 2번의 release 태그를 활용하기 때문

## 추가정보
-
